### PR TITLE
feat(maps): FAA VFR sectional/terminal charts (base layer + overlay + offline)

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -254,6 +254,45 @@ FlightMap {
         }
     }
 
+    // FAA VFR aeronautical chart rendered as a translucent layer on top of the
+    // active base map. It is a second tiled Map (input-disabled) whose camera is
+    // bound to the base map; reuses the same tile engine so offline-cached tiles
+    // work here too.
+    Map {
+        id:             vfrOverlayMap
+        anchors.fill:   parent
+        z:              0
+        enabled:        false   // pass all gestures/clicks through to the base map
+        visible:        QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled.rawValue && !pipMode
+        opacity:        QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.rawValue
+        plugin:         Plugin { name: "QGroundControl" }
+        gesture.enabled: false
+        color:          "transparent"
+
+        center:         _root.center
+        zoomLevel:      _root.zoomLevel
+        bearing:        _root.bearing
+        tilt:           _root.tilt
+        fieldOfView:    _root.fieldOfView
+
+        function updateVfrMapType() {
+            var want = QGroundControl.settingsManager.flightMapSettings.vfrOverlayType.value
+            for (var i = 0; i < vfrOverlayMap.supportedMapTypes.length; i++) {
+                if (vfrOverlayMap.supportedMapTypes[i].name === want) {
+                    vfrOverlayMap.activeMapType = vfrOverlayMap.supportedMapTypes[i]
+                    return
+                }
+            }
+        }
+
+        Component.onCompleted: updateVfrMapType()
+
+        Connections {
+            target:                 QGroundControl.settingsManager.flightMapSettings.vfrOverlayType
+            function onRawValueChanged() { vfrOverlayMap.updateVfrMapType() }
+        }
+    }
+
     MapFitFunctions {
         id:                         mapFitFunctions // The name for this id cannot be changed without breaking references outside of this code. Beware!
         map:                        _root

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(QtLocationPlugin
 	BingMapProvider.cpp
 	ElevationMapProvider.cpp
 	EsriMapProvider.cpp
+	FAAMapProvider.cpp
 	GenericMapProvider.cpp
 	GoogleMapProvider.cpp
 	MapboxMapProvider.cpp

--- a/src/QtLocationPlugin/FAAMapProvider.cpp
+++ b/src/QtLocationPlugin/FAAMapProvider.cpp
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "FAAMapProvider.h"
+
+// FAA-operated ArcGIS Online hosted tile caches. Note ESRI tile addressing is
+// {zoom}/{row=y}/{col=x}, the opposite arg order from XYZ providers.
+static const QString VFRSectionalUrl =
+    QStringLiteral("https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/VFR_Sectional/MapServer/tile/%1/%2/%3");
+
+QString FAAVFRSectionalMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    // The chart cache has no tiles above its native resolution; returning an
+    // empty URL makes the renderer/downloader skip the request instead of
+    // hammering the server with 404s.
+    if (zoom > maxZoomSupported()) {
+        return QString();
+    }
+    return VFRSectionalUrl.arg(zoom).arg(y).arg(x);
+}
+
+static const QString VFRTerminalUrl =
+    QStringLiteral("https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/VFR_Terminal/MapServer/tile/%1/%2/%3");
+
+QString FAAVFRTerminalMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    if (zoom > maxZoomSupported()) {
+        return QString();
+    }
+    return VFRTerminalUrl.arg(zoom).arg(y).arg(x);
+}

--- a/src/QtLocationPlugin/FAAMapProvider.h
+++ b/src/QtLocationPlugin/FAAMapProvider.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "MapProvider.h"
+
+// FAA aeronautical raster charts, served from the FAA's own ArcGIS Online
+// hosted tile caches (Web Mercator, anonymous access, ESRI {z}/{y}/{x} order).
+class FAAVFRSectionalMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    FAAVFRSectionalMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://www.faa.gov/"), QStringLiteral(""),
+                      AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
+
+    int maxZoomSupported() const override { return 12; }
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
+class FAAVFRTerminalMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    FAAVFRTerminalMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://www.faa.gov/"), QStringLiteral(""),
+                      AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
+
+    int maxZoomSupported() const override { return 12; }
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -48,6 +48,12 @@ public:
     virtual bool _isElevationProvider() const { return false; }
     virtual bool _isBingProvider() const { return false; }
 
+    // Highest zoom level for which this provider actually has tiles. Default is
+    // effectively unbounded; providers backed by a fixed tile cache (e.g. the
+    // FAA aeronautical charts) override this so the renderer and the offline
+    // downloader don't request non-existent tiles.
+    virtual int maxZoomSupported() const { return 22; }
+
     virtual QGCTileSet getTileCount(const int zoom, const double topleftLon,
                                      const double topleftLat, const double bottomRightLon,
                                      const double bottomRightLat) const;

--- a/src/QtLocationPlugin/QGCLocationPlugin.pri
+++ b/src/QtLocationPlugin/QGCLocationPlugin.pri
@@ -29,6 +29,7 @@ HEADERS += \
     $$PWD/BingMapProvider.h \
     $$PWD/GenericMapProvider.h \
     $$PWD/EsriMapProvider.h \
+    $$PWD/FAAMapProvider.h \
     $$PWD/MapboxMapProvider.h \
     $$PWD/QGCTileSet.h \
 
@@ -50,6 +51,7 @@ SOURCES += \
     $$PWD/BingMapProvider.cpp \
     $$PWD/GenericMapProvider.cpp \
     $$PWD/EsriMapProvider.cpp \
+    $$PWD/FAAMapProvider.cpp \
     $$PWD/MapboxMapProvider.cpp \
 
 OTHER_FILES += \

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -330,11 +330,21 @@ QGCCachedTileSet::_networkReplyError(QNetworkReply::NetworkError error)
     if (!reply) {
         return;
     }
-    //-- Update error count
-    _errorCount++;
-    emit errorCountChanged();
     //-- Get tile hash
     QString hash = reply->request().attribute(QNetworkRequest::User).toString();
+    //-- The FAA chart caches genuinely have no tile outside chart coverage. A
+    //   404 there means "nothing to download here", not a failure, so don't
+    //   flag it as an error (otherwise an out-of-coverage area looks like a
+    //   wall of errors). Mark the tile complete so the set finishes cleanly.
+    const bool faaNoCoverage =
+        (error == QNetworkReply::ContentNotFoundError) &&
+        !hash.isEmpty() &&
+        getQGCMapEngine()->hashToType(hash).startsWith(QStringLiteral("FAA "));
+    if (!faaNoCoverage) {
+        //-- Update error count
+        _errorCount++;
+        emit errorCountChanged();
+    }
     qCDebug(QGCCachedTileSetLog) << "Error fetching tile" << reply->errorString();
     if(!hash.isEmpty()) {
         if(_replies.contains(hash)) {
@@ -342,10 +352,10 @@ QGCCachedTileSet::_networkReplyError(QNetworkReply::NetworkError error)
         } else {
             qWarning() << "QGCMapEngineManager::networkReplyError() Reply not in list: " << hash;
         }
-        if (error != QNetworkReply::OperationCanceledError) {
+        if (!faaNoCoverage && error != QNetworkReply::OperationCanceledError) {
             qWarning() << "QGCMapEngineManager::networkReplyError() Error:" << reply->errorString();
         }
-        QGCUpdateTileDownloadStateTask* task = new QGCUpdateTileDownloadStateTask(_id, QGCTile::StateError, hash);
+        QGCUpdateTileDownloadStateTask* task = new QGCUpdateTileDownloadStateTask(_id, faaNoCoverage ? QGCTile::StateComplete : QGCTile::StateError, hash);
         getQGCMapEngine()->addTask(task);
     } else {
         qWarning() << "QGCMapEngineManager::networkReplyError() Empty Hash";

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -89,6 +89,9 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["LINZ Basemap"] = new LINZBasemapMapProvider(this);
 
     _providersTable["CustomURL Custom"] = new CustomURLMapProvider(this);
+
+    _providersTable["FAA VFR Sectional"] = new FAAVFRSectionalMapProvider(this);
+    _providersTable["FAA VFR Terminal"]  = new FAAVFRTerminalMapProvider(this);
 }
 
 void UrlFactory::registerProvider(QString name, MapProvider* provider) {

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -23,6 +23,7 @@
 #include "EsriMapProvider.h"
 #include "MapboxMapProvider.h"
 #include "ElevationMapProvider.h"
+#include "FAAMapProvider.h"
 
 #define MAX_MAP_ZOOM (23.0)
 

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -177,7 +177,14 @@ QGeoTiledMapReplyQGC::networkReplyError(QNetworkReply::NetworkError error)
     } else {
         //-- Regular map tile
         if (error != QNetworkReply::OperationCanceledError) {
-            qWarning() << "Fetch tile error:" << _reply->errorString();
+            //-- FAA charts have no tile outside chart coverage; a 404 there is
+            //   expected, so don't spam the log for every out-of-coverage tile.
+            const bool faaNoCoverage =
+                (error == QNetworkReply::ContentNotFoundError) &&
+                getQGCMapEngine()->urlFactory()->getTypeFromId(tileSpec().mapId()).startsWith(QStringLiteral("FAA "));
+            if (!faaNoCoverage) {
+                qWarning() << "Fetch tile error:" << _reply->errorString();
+            }
             setError(QGeoTiledMapReply::CommunicationError, _reply->errorString());
         }
         setFinished(true);

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -60,7 +60,10 @@ Item {
     property bool   _tooManyTiles:      QGroundControl.mapEngineManager.tileCount > _maxTilesForDownload
 
     readonly property real minZoomLevel:    1
-    readonly property real maxZoomLevel:    20
+    // Some providers (e.g. FAA aeronautical charts) only have tiles up to a
+    // fixed zoom; cap the download sliders so the user can't queue thousands
+    // of non-existent tiles.
+    property real maxZoomLevel:    QGroundControl.mapEngineManager.maxZoomForMapType(mapType)
     readonly property real sliderTouchArea: ScreenTools.defaultFontPixelWidth * (ScreenTools.isTinyScreen ? 5 : (ScreenTools.isMobile ? 6 : 3))
 
     readonly property int _maxTilesForDownload: _settings ? _settings.maxTilesForDownload.rawValue : 0
@@ -109,6 +112,10 @@ Item {
         isMapInteractive = true
         mapType = _fmSettings.mapProvider.value + " " + _fmSettings.mapType.value
         resetMapToDefaults()
+        // Re-sync the preview explicitly: when mapType is unchanged from the
+        // previous set, onMapTypeChanged won't fire and the map would otherwise
+        // keep a stale (often satellite) activeMapType.
+        updateMap()
         handleChanges()
         _map.visible = true
         _tileSetList.visible = false
@@ -807,23 +814,21 @@ Item {
                             anchors.left:   parent.left
                             anchors.right:  parent.right
                             model:          QGroundControl.mapEngineManager.mapList
+                            // Keep the dropdown bound to mapType so the shown
+                            // value can never desync from what actually gets
+                            // downloaded (which also drives the elevation skip).
+                            currentIndex:   Math.max(0, mapCombo.find(mapType))
                             onActivated: {
                                 mapType = textAt(index)
-                            }
-                            Component.onCompleted: {
-                                var index = mapCombo.find(mapType)
-                                if (index === -1) {
-                                    console.warn("Active map name not in combo", mapType)
-                                } else {
-                                    mapCombo.currentIndex = index
-                                }
                             }
                         }
                         QGCCheckBox {
                             anchors.left:   parent.left
                             anchors.right:  parent.right
-                            text:           qsTr("Fetch elevation data")
-                            checked:        QGroundControl.mapEngineManager.fetchElevation
+                            // Elevation data does not apply to the FAA chart caches
+                            enabled:        mapType.indexOf("FAA ") !== 0
+                            text:           enabled ? qsTr("Fetch elevation data") : qsTr("N/A for FAA charts")
+                            checked:        enabled && QGroundControl.mapEngineManager.fetchElevation
                             onClicked: {
                                 QGroundControl.mapEngineManager.fetchElevation = checked
                                 handleChanges()

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -85,7 +85,9 @@ QGCMapEngineManager::updateForCurrentView(double lon0, double lat0, double lon1,
         QGCTileSet set = QGCMapEngine::getTileCount(z, lon0, lat0, lon1, lat1, mapName);
         _imageSet += set;
     }
-    if (_fetchElevation) {
+    // Elevation data is meaningless for (and cannot be co-downloaded with) the
+    // FAA aeronautical chart caches, so never include it for those.
+    if (_fetchElevation && !mapName.startsWith(QStringLiteral("FAA "))) {
         QGCTileSet set = QGCMapEngine::getTileCount(1, lon0, lat0, lon1, lat1, kElevationMapType);
         _elevationSet += set;
     }
@@ -161,7 +163,7 @@ QGCMapEngineManager::startDownload(const QString& name, const QString& mapType)
     } else {
         qWarning() <<  "QGCMapEngineManager::startDownload() No Tiles to save";
     }
-    if (mapType != kElevationMapType && _fetchElevation) {
+    if (mapType != kElevationMapType && _fetchElevation && !mapType.startsWith(QStringLiteral("FAA "))) {
         QGCCachedTileSet* set = new QGCCachedTileSet(name + " Elevation");
         set->setMapTypeStr(kElevationMapType);
         set->setTopleftLat(_topleftLat);
@@ -239,6 +241,17 @@ QGCMapEngineManager::mapTypeList(QString provider)
     mapList.replaceInStrings(QRegExp("^([^\\ ]*) (.*)$"),"\\2");
     mapList.removeDuplicates();
     return mapList;
+}
+
+//-----------------------------------------------------------------------------
+int
+QGCMapEngineManager::maxZoomForMapType(const QString& mapType)
+{
+    UrlFactory* urlFactory = getQGCMapEngine()->urlFactory();
+    MapProvider* provider = urlFactory->getMapProviderFromId(urlFactory->getIdFromType(mapType));
+    // Never raise the default ceiling for normal providers; only providers
+    // backed by a fixed tile cache report a lower value.
+    return provider ? qMin(20, provider->maxZoomSupported()) : 20;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -61,6 +61,7 @@ public:
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
     Q_INVOKABLE void                startDownload           (const QString& name, const QString& mapType);
+    Q_INVOKABLE int                 maxZoomForMapType       (const QString& mapType);
     Q_INVOKABLE void                saveSetting             (const QString& key,  const QString& value);
     Q_INVOKABLE QString             loadSetting             (const QString& key,  const QString& defaultValue);
     Q_INVOKABLE void                deleteTileSet           (QGCCachedTileSet* tileSet);

--- a/src/Settings/FlightMap.SettingsGroup.json
+++ b/src/Settings/FlightMap.SettingsGroup.json
@@ -14,6 +14,29 @@
     "shortDesc": "Currently selected map type for flight maps",
     "type":             "string",
     "default":     "Hybrid"
+},
+{
+    "name":             "vfrOverlayEnabled",
+    "shortDesc":        "Show FAA VFR aeronautical chart as a transparent overlay on the flight map",
+    "type":             "bool",
+    "default":          false
+},
+{
+    "name":             "vfrOverlayOpacity",
+    "shortDesc":        "Opacity of the FAA VFR chart overlay",
+    "type":             "double",
+    "min":              0.1,
+    "max":              1.0,
+    "decimalPlaces":    2,
+    "default":          0.65
+},
+{
+    "name":             "vfrOverlayType",
+    "shortDesc":        "Which FAA VFR chart to use for the overlay",
+    "type":             "string",
+    "enumStrings":      "Sectional,Terminal",
+    "enumValues":       "FAA VFR Sectional,FAA VFR Terminal",
+    "default":          "FAA VFR Sectional"
 }
 ]
 }

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -23,3 +23,6 @@ DECLARE_SETTINGGROUP(FlightMap, "FlightMap")
 
 DECLARE_SETTINGSFACT(FlightMapSettings, mapProvider)
 DECLARE_SETTINGSFACT(FlightMapSettings, mapType)
+DECLARE_SETTINGSFACT(FlightMapSettings, vfrOverlayEnabled)
+DECLARE_SETTINGSFACT(FlightMapSettings, vfrOverlayOpacity)
+DECLARE_SETTINGSFACT(FlightMapSettings, vfrOverlayType)

--- a/src/Settings/FlightMapSettings.h
+++ b/src/Settings/FlightMapSettings.h
@@ -22,5 +22,8 @@ public:
     DEFINE_SETTING_NAME_GROUP()
     DEFINE_SETTINGFACT(mapProvider)
     DEFINE_SETTINGFACT(mapType)
+    DEFINE_SETTINGFACT(vfrOverlayEnabled)
+    DEFINE_SETTINGFACT(vfrOverlayOpacity)
+    DEFINE_SETTINGFACT(vfrOverlayType)
 
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -669,6 +669,47 @@ Rectangle {
                                 }
 
                                 QGCLabel {
+                                    text:       qsTr("VFR Chart Overlay")
+                                    width:      _labelWidth
+                                }
+                                FactCheckBox {
+                                    text:       qsTr("Show FAA sectional over map")
+                                    fact:       QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled
+                                }
+
+                                QGCLabel {
+                                    text:       qsTr("VFR Chart Type")
+                                    width:      _labelWidth
+                                    enabled:    QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled.rawValue
+                                }
+                                FactComboBox {
+                                    Layout.preferredWidth:  _comboFieldWidth
+                                    fact:                   QGroundControl.settingsManager.flightMapSettings.vfrOverlayType
+                                    indexModel:             false
+                                    enabled:                QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled.rawValue
+                                }
+
+                                QGCLabel {
+                                    text:       qsTr("VFR Overlay Opacity")
+                                    width:      _labelWidth
+                                    enabled:    QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled.rawValue
+                                }
+                                QGCSlider {
+                                    Layout.preferredWidth:  _comboFieldWidth
+                                    minimumValue:           QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.min
+                                    maximumValue:           QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.max
+                                    stepSize:               0.05
+                                    displayValue:           true
+                                    enabled:                QGroundControl.settingsManager.flightMapSettings.vfrOverlayEnabled.rawValue
+                                    value:                  QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.rawValue
+                                    onValueChanged: {
+                                        if (Math.abs(value - QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.rawValue) > 0.001) {
+                                            QGroundControl.settingsManager.flightMapSettings.vfrOverlayOpacity.rawValue = value
+                                        }
+                                    }
+                                }
+
+                                QGCLabel {
                                     text:                   qsTr("Stream GCS Position")
                                     visible:                _followTarget.visible
                                 }


### PR DESCRIPTION
## Summary
Ports the FAA VFR aeronautical chart feature from the AAGS tree into this fork (adapted for the Copernicus elevation key / `kElevationMapType`).

- **New `FAAMapProvider`** (VFR Sectional, VFR Terminal) sourced from the FAA's own ArcGIS Online tile caches (anonymous, Web Mercator, ESRI `{z}/{y}/{x}`). Registered in `UrlFactory`, so the charts are **selectable base layers** and **download offline** via the existing tile-cache infrastructure.
- **Translucent overlay**: General Settings gains enable / opacity / chart-type controls; `FlyViewMap` renders a camera-bound, input-disabled overlay `Map` so the sectional can sit on top of any base map.
- **Real max zoom (12)**: renderer and offline downloader skip tiles above native chart resolution (no higher-res tiles exist).
- **Offline robustness**: per-provider zoom-slider clamp; skip the never-completing elevation set for FAA charts; treat out-of-coverage `404`s as "no tile here" rather than hard errors / log spam.

17 files changed (15 modified + 2 new: `FAAMapProvider.{h,cpp}`).

## Test plan
- [ ] General → Map Provider → "FAA" / "VFR Sectional": chart renders over CONUS
- [ ] Enable VFR overlay over satellite; opacity slider blends; toggling off clears it
- [ ] Offline download of a charted land area at z≤12 completes with 0 errors; no elevation set created
- [ ] Out-of-coverage selection finishes quietly (no error wall / crash)
- [ ] Second "Add New Set" without leaving keeps the sectional preview (not satellite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)