### PR TITLE
feat(parameters): import parameter metadata from a PX4 firmware/XML file

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -27,10 +27,12 @@ MacBuild {
         # SDL2 Framework
         QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.framework $BUILT_PRODUCTS_DIR/$${TARGET}.app/Contents/Frameworks
         QMAKE_POST_LINK += && install_name_tool -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $BUILT_PRODUCTS_DIR/$${TARGET}.app/Contents/MacOS/$${TARGET}
+        QMAKE_POST_LINK += && bash $$SOURCE_DIR/tools/bundle_zlib_macos.sh $BUILT_PRODUCTS_DIR/$${TARGET}.app $${TARGET}
     } else {
         # SDL2 Framework
         QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.framework $${TARGET}.app/Contents/Frameworks
         QMAKE_POST_LINK += && install_name_tool -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $${TARGET}.app/Contents/MacOS/$${TARGET}
+        QMAKE_POST_LINK += && bash $$SOURCE_DIR/tools/bundle_zlib_macos.sh $${TARGET}.app $${TARGET}
     }
 }
 

--- a/src/FactSystem/ParameterManagerTest.cc
+++ b/src/FactSystem/ParameterManagerTest.cc
@@ -12,6 +12,69 @@
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "ParameterManager.h"
+#include "CompInfoParam.h"
+#include "ComponentInformationManager.h"
+#include "FactMetaData.h"
+#include "FirmwarePlugin.h"
+#include "FirmwarePluginManager.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QScopedPointer>
+#include <QTemporaryFile>
+
+namespace {
+QByteArray _testPX4MetaDataXml(const QString& shortDescription)
+{
+    return QStringLiteral(
+        "<parameters>"
+        "<version>3</version>"
+        "<parameter_version_major>1</parameter_version_major>"
+        "<parameter_version_minor>999</parameter_version_minor>"
+        "<group name=\"AAGS Test\">"
+        "<parameter name=\"AAGS_DUMMY\" default=\"0\" type=\"INT32\">"
+        "<short_desc>Dummy parameter</short_desc>"
+        "</parameter>"
+        "<parameter name=\"SYS_AUTOSTART\" default=\"0\" type=\"INT32\">"
+        "<short_desc>%1</short_desc>"
+        "<long_desc>%1</long_desc>"
+        "</parameter>"
+        "</group>"
+        "</parameters>").arg(shortDescription).toUtf8();
+}
+
+bool _writeTempFile(QTemporaryFile& file, const QByteArray& bytes)
+{
+    if (!file.open()) {
+        return false;
+    }
+    if (file.write(bytes) != bytes.count()) {
+        return false;
+    }
+    file.close();
+    return true;
+}
+
+bool _readTempFile(const QString& fileName, QByteArray& bytes)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return false;
+    }
+    bytes = file.readAll();
+    return true;
+}
+
+QByteArray _px4CompressedJsonString(const QByteArray& bytes)
+{
+    QByteArray compressed = qCompress(bytes);
+    compressed.remove(0, 4);
+    return compressed.toBase64();
+}
+}
 
 /// Test failure modes which should still lead to param load success
 void ParameterManagerTest::_noFailureWorker(MockConfiguration::FailureMode_t failureMode)
@@ -230,4 +293,65 @@ void ParameterManagerTest::_FTPChangeParam()
     arguments = spyProgress.takeLast();
     QCOMPARE(arguments.count(), 1);
     QCOMPARE(arguments.at(0).toFloat(), 0.0f);
+}
+
+void ParameterMetadataImportTest::_cachePX4MetadataFromXml(void)
+{
+    const QByteArray xmlBytes = _testPX4MetaDataXml(QStringLiteral("Imported XML metadata"));
+    QTemporaryFile xmlFile(QDir::temp().filePath(QStringLiteral("aags-metadata-XXXXXX.xml")));
+    QVERIFY(_writeTempFile(xmlFile, xmlBytes));
+
+    QString errorString;
+    QString cachedFile;
+    QVERIFY2(CompInfoParam::cachePX4MetaDataFromFile(xmlFile.fileName(), errorString, &cachedFile), qPrintable(errorString));
+    QVERIFY(QFileInfo::exists(cachedFile));
+
+    QByteArray cachedBytes;
+    QVERIFY(_readTempFile(cachedFile, cachedBytes));
+    QCOMPARE(cachedBytes, xmlBytes);
+}
+
+void ParameterMetadataImportTest::_cachePX4MetadataFromFirmware(void)
+{
+    const QByteArray xmlBytes = _testPX4MetaDataXml(QStringLiteral("Imported firmware metadata"));
+    QJsonObject firmwareJson;
+    firmwareJson[QStringLiteral("mav_autopilot")] = MAV_AUTOPILOT_PX4;
+    firmwareJson[QStringLiteral("parameter_xml_size")] = xmlBytes.count();
+    firmwareJson[QStringLiteral("parameter_xml")] = QString::fromUtf8(_px4CompressedJsonString(xmlBytes));
+
+    QTemporaryFile firmwareFile(QDir::temp().filePath(QStringLiteral("aags-firmware-XXXXXX.px4")));
+    QVERIFY(_writeTempFile(firmwareFile, QJsonDocument(firmwareJson).toJson(QJsonDocument::Compact)));
+
+    QString errorString;
+    QString cachedFile;
+    QVERIFY2(CompInfoParam::cachePX4MetaDataFromFile(firmwareFile.fileName(), errorString, &cachedFile), qPrintable(errorString));
+    QVERIFY(QFileInfo::exists(cachedFile));
+
+    QByteArray cachedBytes;
+    QVERIFY(_readTempFile(cachedFile, cachedBytes));
+    QCOMPARE(cachedBytes, xmlBytes);
+}
+
+void ParameterMetadataImportTest::_loadedPX4MetadataUsesImportedXml(void)
+{
+    const QString importedDescription = QStringLiteral("Imported metadata lookup description");
+    const QByteArray xmlBytes = _testPX4MetaDataXml(importedDescription);
+    QTemporaryFile xmlFile(QDir::temp().filePath(QStringLiteral("aags-lookup-XXXXXX.xml")));
+    QVERIFY(_writeTempFile(xmlFile, xmlBytes));
+
+    QString errorString;
+    QString cachedFile;
+    QVERIFY2(CompInfoParam::cachePX4MetaDataFromFile(xmlFile.fileName(), errorString, &cachedFile), qPrintable(errorString));
+
+    FirmwarePlugin* plugin = qgcApp()->toolbox()->firmwarePluginManager()->firmwarePluginForAutopilot(MAV_AUTOPILOT_PX4, MAV_TYPE_FIXED_WING);
+    QVERIFY(plugin);
+
+    QScopedPointer<QObject> opaqueMetaData(plugin->_loadParameterMetaData(cachedFile));
+    QVERIFY(opaqueMetaData);
+
+    FactMetaData* metaData = plugin->_getMetaDataForFact(opaqueMetaData.data(), QStringLiteral("SYS_AUTOSTART"), FactMetaData::valueTypeInt32, MAV_TYPE_FIXED_WING);
+    QVERIFY(metaData);
+
+    QCOMPARE(metaData->shortDescription(), importedDescription);
+    QCOMPARE(metaData->longDescription(), importedDescription);
 }

--- a/src/FactSystem/ParameterManagerTest.h
+++ b/src/FactSystem/ParameterManagerTest.h
@@ -33,4 +33,14 @@ private:
     void _noFailureWorker(MockConfiguration::FailureMode_t failureMode);
 };
 
+class ParameterMetadataImportTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _cachePX4MetadataFromXml(void);
+    void _cachePX4MetadataFromFirmware(void);
+    void _loadedPX4MetadataUsesImportedXml(void);
+};
+
 #endif

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -32,6 +32,7 @@ Item {
     property bool   _showRCToParam:     _activeVehicle.px4Firmware
     property var    _appSettings:       QGroundControl.settingsManager.appSettings
     property var    _controller:        controller
+    property string _fileDialogMode:    "parameters"
 
     ParameterEditorController {
         id: controller
@@ -110,6 +111,15 @@ Item {
             onTriggered:    controller.pullMetadataFromVehicle()
         }
         QGCMenuItem {
+            text:           qsTr("Pull New Metadata...")
+            onTriggered: {
+                _fileDialogMode =           "metadata"
+                fileDialog.title =          qsTr("Pull New Parameter Metadata")
+                fileDialog.selectExisting = true
+                fileDialog.openForLoad()
+            }
+        }
+        QGCMenuItem {
             text:           qsTr("Reset all to firmware's defaults")
             onTriggered:    mainWindow.showMessageDialog(qsTr("Reset All"),
                                                          qsTr("Select Reset to reset all parameters to their defaults.\n\nNote that this will also completely reset everything, including UAVCAN nodes, all vehicle settings, setup and calibrations."),
@@ -128,6 +138,7 @@ Item {
         QGCMenuItem {
             text:           qsTr("Load from file...")
             onTriggered: {
+                _fileDialogMode =           "parameters"
                 fileDialog.title =          qsTr("Load Parameters")
                 fileDialog.selectExisting = true
                 fileDialog.openForLoad()
@@ -136,6 +147,7 @@ Item {
         QGCMenuItem {
             text:           qsTr("Save to file...")
             onTriggered: {
+                _fileDialogMode =           "parameters"
                 fileDialog.title =          qsTr("Save Parameters")
                 fileDialog.selectExisting = false
                 fileDialog.openForSave()
@@ -304,7 +316,9 @@ Item {
     QGCFileDialog {
         id:             fileDialog
         folder:         _appSettings.parameterSavePath
-        nameFilters:    [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*)") ]
+        nameFilters:    _fileDialogMode === "metadata" ?
+                            [ qsTr("Firmware or Metadata Files (*.px4 *.apj *.xml)"), qsTr("PX4 Firmware Files (*.px4 *.apj)"), qsTr("Parameter Metadata XML (*.xml)"), qsTr("All Files (*)") ] :
+                            [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*)") ]
 
         onAcceptedForSave: {
             controller.saveToFile(file)
@@ -313,7 +327,9 @@ Item {
 
         onAcceptedForLoad: {
             close()
-            if (controller.buildDiffFromFile(file)) {
+            if (_fileDialogMode === "metadata") {
+                controller.pullNewMetadataFromFile(file)
+            } else if (controller.buildDiffFromFile(file)) {
                 parameterDiffDialog.createObject(mainWindow).open()
             }
         }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -14,7 +14,9 @@
 #include "AppSettings.h"
 #include "Vehicle.h"
 #include "ComponentInformationManager.h"
+#include "CompInfoParam.h"
 
+#include <QFileInfo>
 #include <QStandardPaths>
 
 #include <memory>
@@ -118,6 +120,29 @@ void ParameterEditorController::_buildLists(void)
             }
         }
     }
+}
+
+void ParameterEditorController::_rebuildLists(void)
+{
+    for (int i = 0; i < _categories.count(); ++i) {
+        ParameterEditorCategory* category = _categories.value<ParameterEditorCategory*>(i);
+        for (int j = 0; j < category->groups.count(); ++j) {
+            category->groups.value<ParameterEditorGroup*>(j)->deleteLater();
+        }
+        category->deleteLater();
+    }
+
+    _categories.clear();
+    _mapCategoryName2Category.clear();
+    _parameters = nullptr;
+    _currentCategory = nullptr;
+    _currentGroup = nullptr;
+
+    _buildLists();
+
+    ParameterEditorCategory* category = _categories.count() ? _categories.value<ParameterEditorCategory*>(0) : nullptr;
+    setCurrentCategory(category);
+    emit parametersChanged();
 }
 
 void ParameterEditorController::_factAdded(int compId, Fact* fact)
@@ -368,6 +393,43 @@ void ParameterEditorController::pullMetadataFromVehicle(void)
 
     qgcApp()->showAppMessage(tr("Pulling parameter metadata from the vehicle, this may take a moment..."));
     compInfoManager->refreshComponentMetadata();
+}
+
+void ParameterEditorController::pullNewMetadataFromFile(const QString& filename)
+{
+    if (filename.isEmpty()) {
+        return;
+    }
+
+    if (!_vehicle->px4Firmware()) {
+        qgcApp()->showAppMessage(tr("Importing metadata from PX4 firmware/XML files is only supported for PX4 vehicles."));
+        return;
+    }
+
+    QString errorString;
+    QString cachedMetaDataFile;
+    if (!CompInfoParam::cachePX4MetaDataFromFile(filename, errorString, &cachedMetaDataFile)) {
+        qgcApp()->showAppMessage(tr("Unable to import parameter metadata: %1").arg(errorString));
+        return;
+    }
+
+    ComponentInformationManager* compInfoManager = _vehicle->compInfoManager();
+    if (!compInfoManager) {
+        qgcApp()->showAppMessage(tr("Unable to import parameter metadata: vehicle component metadata is not available."));
+        return;
+    }
+
+    CompInfoParam* compInfoParam = compInfoManager->compInfoParam(MAV_COMP_ID_AUTOPILOT1);
+    if (!compInfoParam) {
+        qgcApp()->showAppMessage(tr("Unable to import parameter metadata: autopilot parameter metadata is not available."));
+        return;
+    }
+
+    compInfoParam->usePX4MetaDataFile(cachedMetaDataFile);
+    _parameterMgr->reapplyMetadataToAllFacts();
+    _rebuildLists();
+
+    qgcApp()->showAppMessage(tr("Imported parameter metadata from %1.").arg(QFileInfo(filename).fileName()));
 }
 
 void ParameterEditorController::resetAllToDefaults(void)

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -109,6 +109,7 @@ public:
     Q_INVOKABLE void sendDiff                       (void);
     Q_INVOKABLE void refresh                        (void);
     Q_INVOKABLE void pullMetadataFromVehicle        (void);
+    Q_INVOKABLE void pullNewMetadataFromFile        (const QString& filename);
     Q_INVOKABLE void resetAllToDefaults             (void);
     Q_INVOKABLE void resetAllToVehicleConfiguration (void);
 
@@ -138,6 +139,7 @@ private slots:
 
 private:
     bool _shouldShow(Fact *fact) const;
+    void _rebuildLists(void);
 
 private:
     ParameterManager*           _parameterMgr           = nullptr;

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -14,15 +14,244 @@
 #include "FirmwarePluginManager.h"
 #include "QGCApplication.h"
 
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QStandardPaths>
+#include <QSettings>
 #include <QJsonDocument>
+#include <QJsonObject>
 #include <QJsonArray>
+#include <QSaveFile>
+#include <QXmlStreamReader>
 
 QGC_LOGGING_CATEGORY(CompInfoParamLog, "CompInfoParamLog")
 
 const char* CompInfoParam::_jsonParametersKey           = "parameters";
 const char* CompInfoParam::_cachedMetaDataFilePrefix    = "ParameterFactMetaData";
 const char* CompInfoParam::_indexedNameTag              = "{n}";
+
+namespace {
+const char* kPX4FirmwareParamXmlSizeKey = "parameter_xml_size";
+const char* kPX4FirmwareParamXmlKey     = "parameter_xml";
+const char* kPX4FirmwareMavAutopilotKey = "mav_autopilot";
+
+bool _readFileBytes(const QString& fileName, QByteArray& bytes, QString& errorString)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly)) {
+        errorString = QStringLiteral("Unable to open %1: %2").arg(fileName, file.errorString());
+        return false;
+    }
+
+    bytes = file.readAll();
+    return true;
+}
+
+bool _px4MetaDataVersionInfo(const QByteArray& metaDataBytes, const QString& sourceName, int& majorVersion, int& minorVersion, QString& errorString)
+{
+    majorVersion = -1;
+    minorVersion = -1;
+
+    QXmlStreamReader xml(metaDataBytes);
+    while (!xml.atEnd() && (majorVersion == -1 || minorVersion == -1)) {
+        xml.readNext();
+        if (!xml.isStartElement()) {
+            continue;
+        }
+
+        if (xml.name() == QStringLiteral("parameter_version_major")) {
+            bool convertOk = false;
+            majorVersion = xml.readElementText().toInt(&convertOk);
+            if (!convertOk) {
+                errorString = QStringLiteral("%1 has an invalid parameter_version_major value").arg(sourceName);
+                return false;
+            }
+        } else if (xml.name() == QStringLiteral("parameter_version_minor")) {
+            bool convertOk = false;
+            minorVersion = xml.readElementText().toInt(&convertOk);
+            if (!convertOk) {
+                errorString = QStringLiteral("%1 has an invalid parameter_version_minor value").arg(sourceName);
+                return false;
+            }
+        }
+    }
+
+    if (xml.hasError()) {
+        errorString = QStringLiteral("%1 is not valid XML: %2").arg(sourceName, xml.errorString());
+        return false;
+    }
+    if (majorVersion == -1) {
+        errorString = QStringLiteral("%1 is missing parameter_version_major").arg(sourceName);
+        return false;
+    }
+    if (minorVersion == -1) {
+        errorString = QStringLiteral("%1 is missing parameter_version_minor").arg(sourceName);
+        return false;
+    }
+    if (majorVersion != 1) {
+        errorString = QStringLiteral("%1 has unsupported parameter metadata major version %2").arg(sourceName).arg(majorVersion);
+        return false;
+    }
+
+    return true;
+}
+
+bool _jsonStringValueBytes(const QByteArray& jsonDocBytes, const QString& key, QByteArray& valueBytes, QString& errorString)
+{
+    const QByteArray keyBytes = QByteArray("\"") + key.toUtf8() + QByteArray("\"");
+    const int keyIndex = jsonDocBytes.indexOf(keyBytes);
+    if (keyIndex == -1) {
+        errorString = QStringLiteral("Firmware file is missing %1").arg(key);
+        return false;
+    }
+
+    const int colonIndex = jsonDocBytes.indexOf(':', keyIndex + keyBytes.count());
+    if (colonIndex == -1) {
+        errorString = QStringLiteral("Firmware file has an invalid %1 entry").arg(key);
+        return false;
+    }
+
+    const int quoteStart = jsonDocBytes.indexOf('"', colonIndex + 1);
+    if (quoteStart == -1) {
+        errorString = QStringLiteral("Firmware file has an invalid %1 string").arg(key);
+        return false;
+    }
+
+    int quoteEnd = -1;
+    bool escaped = false;
+    for (int i = quoteStart + 1; i < jsonDocBytes.count(); ++i) {
+        const char ch = jsonDocBytes.at(i);
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (ch == '"') {
+            quoteEnd = i;
+            break;
+        }
+    }
+
+    if (quoteEnd == -1) {
+        errorString = QStringLiteral("Firmware file has an unterminated %1 string").arg(key);
+        return false;
+    }
+
+    valueBytes = jsonDocBytes.mid(quoteStart + 1, quoteEnd - quoteStart - 1);
+    valueBytes.replace("\\/", "/");
+    return true;
+}
+
+bool _decompressPX4FirmwareJsonValue(const QJsonObject& jsonObject, const QByteArray& jsonDocBytes, const QString& sizeKey, const QString& bytesKey, QByteArray& decompressedBytes, QString& errorString)
+{
+    if (!jsonObject.contains(sizeKey)) {
+        errorString = QStringLiteral("Firmware file is missing %1").arg(sizeKey);
+        return false;
+    }
+
+    const int decompressedSize = jsonObject.value(sizeKey).toInt();
+    if (decompressedSize <= 0) {
+        errorString = QStringLiteral("Firmware file has invalid decompressed size for %1").arg(sizeKey);
+        return false;
+    }
+
+    QByteArray raw64;
+    if (!_jsonStringValueBytes(jsonDocBytes, bytesKey, raw64, errorString)) {
+        return false;
+    }
+
+    QByteArray raw;
+    raw.append(static_cast<char>((decompressedSize >> 24) & 0xFF));
+    raw.append(static_cast<char>((decompressedSize >> 16) & 0xFF));
+    raw.append(static_cast<char>((decompressedSize >> 8) & 0xFF));
+    raw.append(static_cast<char>((decompressedSize >> 0) & 0xFF));
+    raw.append(QByteArray::fromBase64(raw64));
+
+    decompressedBytes = qUncompress(raw);
+    if (decompressedBytes.isEmpty()) {
+        errorString = QStringLiteral("Firmware file has 0 length %1").arg(bytesKey);
+        return false;
+    }
+    if (decompressedBytes.count() != decompressedSize) {
+        errorString = QStringLiteral("Size for decompressed %1 does not match stored size: Expected(%2) Actual(%3)").arg(bytesKey).arg(decompressedSize).arg(decompressedBytes.count());
+        return false;
+    }
+
+    return true;
+}
+
+bool _cachePX4MetaDataBytes(const QByteArray& metaDataBytes, const QString& sourceName, QString& errorString, QString* cachedMetaDataFile)
+{
+    int newMajorVersion = -1;
+    int newMinorVersion = -1;
+    if (!_px4MetaDataVersionInfo(metaDataBytes, sourceName, newMajorVersion, newMinorVersion, errorString)) {
+        return false;
+    }
+
+    QSettings settings;
+    QDir cacheDir = QFileInfo(settings.fileName()).dir();
+    if (!cacheDir.exists() && !cacheDir.mkpath(QStringLiteral("."))) {
+        errorString = QStringLiteral("Unable to create metadata cache directory: %1").arg(cacheDir.absolutePath());
+        return false;
+    }
+
+    const QString cacheFileName = cacheDir.filePath(QStringLiteral("ParameterFactMetaData.%1.%2.xml").arg(MAV_AUTOPILOT_PX4).arg(newMajorVersion));
+    QSaveFile cacheFile(cacheFileName);
+    if (!cacheFile.open(QIODevice::WriteOnly)) {
+        errorString = QStringLiteral("Unable to open metadata cache file %1: %2").arg(cacheFileName, cacheFile.errorString());
+        return false;
+    }
+
+    if (cacheFile.write(metaDataBytes) != metaDataBytes.count()) {
+        errorString = QStringLiteral("Unable to write metadata cache file %1: %2").arg(cacheFileName, cacheFile.errorString());
+        return false;
+    }
+
+    if (!cacheFile.commit()) {
+        errorString = QStringLiteral("Unable to commit metadata cache file %1: %2").arg(cacheFileName, cacheFile.errorString());
+        return false;
+    }
+
+    qCDebug(CompInfoParamLog) << "Cached PX4 parameter metadata" << cacheFileName << "major:minor" << newMajorVersion << newMinorVersion;
+    if (cachedMetaDataFile) {
+        *cachedMetaDataFile = cacheFileName;
+    }
+
+    return true;
+}
+
+bool _cachePX4MetaDataFromFirmwareFile(const QString& firmwareFileName, QString& errorString, QString* cachedMetaDataFile)
+{
+    QByteArray firmwareBytes;
+    if (!_readFileBytes(firmwareFileName, firmwareBytes, errorString)) {
+        return false;
+    }
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(firmwareBytes, &parseError);
+    if (doc.isNull() || !doc.isObject()) {
+        errorString = QStringLiteral("%1 is not a valid PX4 firmware JSON file: %2").arg(firmwareFileName, parseError.errorString());
+        return false;
+    }
+
+    const QJsonObject px4Json = doc.object();
+    if (px4Json.contains(kPX4FirmwareMavAutopilotKey) && px4Json.value(kPX4FirmwareMavAutopilotKey).toInt(MAV_AUTOPILOT_PX4) != MAV_AUTOPILOT_PX4) {
+        errorString = QStringLiteral("%1 does not contain PX4 parameter metadata").arg(firmwareFileName);
+        return false;
+    }
+
+    QByteArray parameterXmlBytes;
+    if (!_decompressPX4FirmwareJsonValue(px4Json, firmwareBytes, kPX4FirmwareParamXmlSizeKey, kPX4FirmwareParamXmlKey, parameterXmlBytes, errorString)) {
+        return false;
+    }
+
+    return _cachePX4MetaDataBytes(parameterXmlBytes, firmwareFileName, errorString, cachedMetaDataFile);
+}
+}
 
 CompInfoParam::CompInfoParam(uint8_t compId, Vehicle* vehicle, QObject* parent)
     : CompInfo(COMP_METADATA_TYPE_PARAMETER, compId, vehicle, parent)
@@ -42,8 +271,6 @@ void CompInfoParam::setJson(const QString& metadataJsonFileName)
 
     QString         errorString;
     QJsonDocument   jsonDoc;
-
-    _noJsonMetadata = false;
 
     if (!JsonHelper::isJsonFile(metadataJsonFileName, jsonDoc, errorString)) {
         qCWarning(CompInfoParamLog) << "Metadata json file open failed: compid:" << compId << errorString;
@@ -66,16 +293,15 @@ void CompInfoParam::setJson(const QString& metadataJsonFileName)
         return;
     }
 
+    _noJsonMetadata = false;
+    _manualPX4MetaDataFile.clear();
+    _clearOpaqueParameterMetaData();
+
     // Discard any previously parsed metadata so a re-pull from the vehicle
     // replaces it rather than duplicating into the indexed list / leaking the
     // old FactMetaData objects. Only done now that the new json validated, so a
     // failed re-pull leaves the existing metadata intact.
-    qDeleteAll(_nameToMetaDataMap);
-    _nameToMetaDataMap.clear();
-    for (const RegexFactMetaDataPair_t& pair : _indexedNameMetaDataList) {
-        delete pair.second;
-    }
-    _indexedNameMetaDataList.clear();
+    _clearJsonParameterMetaData();
 
     QJsonArray rgParameters = jsonObj[_jsonParametersKey].toArray();
     for (QJsonValue parameterValue: rgParameters) {
@@ -94,6 +320,30 @@ void CompInfoParam::setJson(const QString& metadataJsonFileName)
             _nameToMetaDataMap[newMetaData->name()] = newMetaData;
         }
     }
+}
+
+void CompInfoParam::_clearJsonParameterMetaData(void)
+{
+    qDeleteAll(_nameToMetaDataMap);
+    _nameToMetaDataMap.clear();
+    for (const RegexFactMetaDataPair_t& pair : _indexedNameMetaDataList) {
+        delete pair.second;
+    }
+    _indexedNameMetaDataList.clear();
+}
+
+void CompInfoParam::_clearOpaqueParameterMetaData(void)
+{
+    delete _opaqueParameterMetaData;
+    _opaqueParameterMetaData = nullptr;
+}
+
+void CompInfoParam::usePX4MetaDataFile(const QString& metaDataFile)
+{
+    _manualPX4MetaDataFile = metaDataFile;
+    _noJsonMetadata = true;
+    _clearJsonParameterMetaData();
+    _clearOpaqueParameterMetaData();
 }
 
 FactMetaData* CompInfoParam::factMetaDataForName(const QString& name, FactMetaData::ValueType_t type)
@@ -229,8 +479,8 @@ QString CompInfoParam::_parameterMetaDataFile(Vehicle* vehicle, MAV_AUTOPILOT fi
             // Cache hit is available, we need to check if internal meta data is a better match, if so use internal version
             if (internalMajorVersion == wantedMajorVersion) {
                 if (cacheMajorVersion == wantedMajorVersion) {
-                    // Both internal and cache are direct hit on major version, Use higher minor version number
-                    cacheHit = cacheMinorVersion > internalMinorVersion;
+                    // A direct cache hit came from flashed/imported firmware, so prefer it over bundled metadata.
+                    cacheHit = true;
                 } else {
                     // Direct internal hit, but not direct hit in cache, use internal
                     cacheHit = false;
@@ -264,48 +514,34 @@ QString CompInfoParam::_parameterMetaDataFile(Vehicle* vehicle, MAV_AUTOPILOT fi
 
 void CompInfoParam::_cachePX4MetaDataFile(const QString& metaDataFile)
 {
-    FirmwarePlugin* plugin = _anyVehicleTypeFirmwarePlugin(MAV_AUTOPILOT_PX4);
-
-    int newMajorVersion, newMinorVersion;
-    plugin->_getParameterMetaDataVersionInfo(metaDataFile, newMajorVersion, newMinorVersion);
-    if (newMajorVersion != 1) {
-        newMajorVersion = 1;
-        qgcApp()->showAppMessage(tr("Internal Error: Parameter MetaData major must be 1"));
+    QString errorString;
+    if (!cachePX4MetaDataFile(metaDataFile, errorString)) {
+        qgcApp()->showAppMessage(errorString);
     }
-    qCDebug(CompInfoParamLog) << "ParameterManager::cacheMetaDataFile file:major;minor" << metaDataFile << newMajorVersion << newMinorVersion;
+}
 
-    // Find the cache hit closest to this new file
-    int cacheMajorVersion, cacheMinorVersion;
-    QString cacheHit = _parameterMetaDataFile(nullptr, MAV_AUTOPILOT_PX4, cacheMajorVersion, cacheMinorVersion);
-    qCDebug(CompInfoParamLog) << "ParameterManager::cacheMetaDataFile cacheHit file:firmware:major;minor" << cacheHit << cacheMajorVersion << cacheMinorVersion;
-
-    bool cacheNewFile = false;
-    if (cacheHit.isEmpty()) {
-        // No cache hits, store the new file
-        cacheNewFile = true;
-    } else if (cacheMajorVersion == newMajorVersion) {
-        // Direct hit on major version in cache:
-        //      Cache new file if newer/equal minor version. We cache if equal to allow flashing test builds with new parameter metadata.
-        //      Also delete older cache file.
-        if (newMinorVersion >= cacheMinorVersion) {
-            cacheNewFile = true;
-            QFile::remove(cacheHit);
-        }
-    } else {
-        // Indirect hit in cache, store new file
-        cacheNewFile = true;
+bool CompInfoParam::cachePX4MetaDataFile(const QString& metaDataFile, QString& errorString, QString* cachedMetaDataFile)
+{
+    QByteArray metaDataBytes;
+    if (!_readFileBytes(metaDataFile, metaDataBytes, errorString)) {
+        return false;
     }
 
-    if (cacheNewFile) {
-        // Cached files are stored in settings location. Copy from current file to cache naming.
+    return _cachePX4MetaDataBytes(metaDataBytes, metaDataFile, errorString, cachedMetaDataFile);
+}
 
-        QSettings settings;
-        QDir cacheDir = QFileInfo(settings.fileName()).dir();
-        QFile cacheFile(cacheDir.filePath(QString("%1.%2.%3.xml").arg(_cachedMetaDataFilePrefix).arg(MAV_AUTOPILOT_PX4).arg(newMajorVersion)));
-        qCDebug(CompInfoParamLog) << "ParameterManager::cacheMetaDataFile caching file:" << cacheFile.fileName();
-        QFile newFile(metaDataFile);
-        newFile.copy(cacheFile.fileName());
+bool CompInfoParam::cachePX4MetaDataFromFile(const QString& metaDataFile, QString& errorString, QString* cachedMetaDataFile)
+{
+    const QString suffix = QFileInfo(metaDataFile).suffix().toLower();
+    if (suffix == QStringLiteral("xml")) {
+        return cachePX4MetaDataFile(metaDataFile, errorString, cachedMetaDataFile);
     }
+    if (suffix == QStringLiteral("px4") || suffix == QStringLiteral("apj")) {
+        return _cachePX4MetaDataFromFirmwareFile(metaDataFile, errorString, cachedMetaDataFile);
+    }
+
+    errorString = tr("Unsupported metadata file type. Select a PX4 firmware file (.px4/.apj) or parameter metadata XML file (.xml).");
+    return false;
 }
 
 QObject* CompInfoParam::_getOpaqueParameterMetaData(void)
@@ -317,7 +553,10 @@ QObject* CompInfoParam::_getOpaqueParameterMetaData(void)
     if (!_opaqueParameterMetaData && compId == MAV_COMP_ID_AUTOPILOT1) {
         // Load best parameter meta data set
         int majorVersion, minorVersion;
-        QString metaDataFile = _parameterMetaDataFile(vehicle, vehicle->firmwareType(), majorVersion, minorVersion);
+        QString metaDataFile = _manualPX4MetaDataFile;
+        if (metaDataFile.isEmpty()) {
+            metaDataFile = _parameterMetaDataFile(vehicle, vehicle->firmwareType(), majorVersion, minorVersion);
+        }
         qCDebug(CompInfoParamLog) << "Loading meta data the old way file" << metaDataFile;
         _opaqueParameterMetaData = vehicle->firmwarePlugin()->_loadParameterMetaData(metaDataFile);
     }

--- a/src/Vehicle/CompInfoParam.h
+++ b/src/Vehicle/CompInfoParam.h
@@ -30,14 +30,19 @@ public:
     CompInfoParam(uint8_t compId, Vehicle* vehicle, QObject* parent = nullptr);
 
     FactMetaData* factMetaDataForName(const QString& name, FactMetaData::ValueType_t type);
+    void usePX4MetaDataFile(const QString& metaDataFile);
 
     // Overrides from CompInfo
     void setJson(const QString& metadataJsonFileName) override;
 
     static void _cachePX4MetaDataFile(const QString& metaDataFile);
+    static bool cachePX4MetaDataFile(const QString& metaDataFile, QString& errorString, QString* cachedMetaDataFile = nullptr);
+    static bool cachePX4MetaDataFromFile(const QString& metaDataFile, QString& errorString, QString* cachedMetaDataFile = nullptr);
 
 private:
     QObject* _getOpaqueParameterMetaData(void);
+    void _clearJsonParameterMetaData(void);
+    void _clearOpaqueParameterMetaData(void);
 
     static FirmwarePlugin*  _anyVehicleTypeFirmwarePlugin   (MAV_AUTOPILOT firmwareType);
     static QString          _parameterMetaDataFile          (Vehicle* vehicle, MAV_AUTOPILOT firmwareType, int& majorVersion, int& minorVersion);
@@ -48,6 +53,7 @@ private:
     FactMetaData::NameToMetaDataMap_t   _nameToMetaDataMap;
     QList<RegexFactMetaDataPair_t>      _indexedNameMetaDataList;
     QObject*                            _opaqueParameterMetaData    = nullptr;
+    QString                             _manualPX4MetaDataFile;
 
     static const char* _cachedMetaDataFilePrefix;
     static const char* _jsonParametersKey;

--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -89,6 +89,7 @@ UT_REGISTER_TEST(CameraCalcTest)
 UT_REGISTER_TEST(FWLandingPatternTest)
 UT_REGISTER_TEST(LandingComplexItemTest)
 
+UT_REGISTER_TEST_STANDALONE(ParameterMetadataImportTest)
 UT_REGISTER_TEST_STANDALONE(MissionCommandTreeEditorTest)
 
 // List of unit test which are currently disabled.

--- a/tools/bundle_zlib_macos.sh
+++ b/tools/bundle_zlib_macos.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Bundle libz when the app binary links a non-system zlib install name.
+#
+# Usage: bundle_zlib_macos.sh <path-to-app-bundle> <main-binary-name>
+#   e.g. bundle_zlib_macos.sh ./AAGS.app AAGS
+
+set -euo pipefail
+
+APP_PATH="${1:?usage: $0 <app-bundle> <main-binary-name>}"
+APP_BIN_NAME="${2:?usage: $0 <app-bundle> <main-binary-name>}"
+
+MAIN_BIN="$APP_PATH/Contents/MacOS/$APP_BIN_NAME"
+FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
+BUNDLED_ZLIB="$FRAMEWORKS_DIR/libz.1.dylib"
+ZLIB_ID="@rpath/libz.1.dylib"
+
+if [ ! -f "$MAIN_BIN" ]; then
+    echo "bundle_zlib_macos: missing app binary at $MAIN_BIN"
+    exit 1
+fi
+
+zlib_dep="$(otool -L "$MAIN_BIN" | awk '
+    NR > 1 {
+        dep=$1
+        if (dep ~ /(^|\/)libz\.1\.dylib$/) {
+            print dep
+            exit
+        }
+    }')"
+
+if [ -z "$zlib_dep" ]; then
+    echo "bundle_zlib_macos: app does not link libz.1.dylib, skipping"
+    exit 0
+fi
+
+if [[ "$zlib_dep" == /usr/lib/* || "$zlib_dep" == /System/* ]]; then
+    echo "bundle_zlib_macos: using system zlib ($zlib_dep), skipping"
+    exit 0
+fi
+
+zlib_candidates=()
+
+if [ -n "${QGC_ZLIB_DYLIB:-}" ]; then
+    zlib_candidates+=("$QGC_ZLIB_DYLIB")
+fi
+
+if [[ "$zlib_dep" == /* ]]; then
+    zlib_candidates+=("$zlib_dep")
+fi
+
+if command -v brew >/dev/null 2>&1; then
+    brew_zlib_prefix="$(brew --prefix zlib 2>/dev/null || true)"
+    if [ -n "$brew_zlib_prefix" ]; then
+        zlib_candidates+=("$brew_zlib_prefix/lib/libz.1.dylib")
+    fi
+fi
+
+zlib_candidates+=(
+    "/opt/homebrew/opt/zlib/lib/libz.1.dylib"
+    "/usr/local/opt/zlib/lib/libz.1.dylib"
+)
+
+zlib_source=""
+for candidate in "${zlib_candidates[@]}"; do
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+        zlib_source="$candidate"
+        break
+    fi
+done
+
+if [ -z "$zlib_source" ]; then
+    echo "bundle_zlib_macos: unable to locate libz.1.dylib for $zlib_dep"
+    echo "bundle_zlib_macos: set QGC_ZLIB_DYLIB to the full libz.1.dylib path if zlib is installed outside Homebrew"
+    exit 1
+fi
+
+mkdir -p "$FRAMEWORKS_DIR"
+cp -f "$zlib_source" "$BUNDLED_ZLIB"
+chmod u+w "$BUNDLED_ZLIB"
+install_name_tool -id "$ZLIB_ID" "$BUNDLED_ZLIB"
+
+if [ "$zlib_dep" != "$ZLIB_ID" ]; then
+    install_name_tool -change "$zlib_dep" "$ZLIB_ID" "$MAIN_BIN"
+fi
+
+# Ad-hoc sign only the dylib we modified. Avoid --deep re-signing the whole app.
+codesign --force --sign - --preserve-metadata=entitlements,requirements,flags,runtime "$BUNDLED_ZLIB" 2>/dev/null \
+    || codesign --force --sign - "$BUNDLED_ZLIB" 2>/dev/null \
+    || true
+
+echo "bundle_zlib_macos: bundled $zlib_source"

--- a/tools/extract_px4_parameter_metadata.py
+++ b/tools/extract_px4_parameter_metadata.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Extract PX4 parameter metadata XML from a .px4/.apj firmware file."""
+
+import argparse
+import base64
+import json
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+import zlib
+
+
+PARAM_XML_SIZE_KEY = "parameter_xml_size"
+PARAM_XML_KEY = "parameter_xml"
+MAV_AUTOPILOT_KEY = "mav_autopilot"
+MAV_AUTOPILOT_PX4 = 12
+
+
+class MetadataExtractError(Exception):
+    pass
+
+
+def _default_output_path(firmware_path):
+    return firmware_path.with_suffix(".parameter.xml")
+
+
+def _read_firmware_json(firmware_path):
+    try:
+        with firmware_path.open("r", encoding="utf-8") as firmware_file:
+            return json.load(firmware_file)
+    except OSError as error:
+        raise MetadataExtractError(f"Unable to open {firmware_path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise MetadataExtractError(f"{firmware_path} is not valid firmware JSON: {error}") from error
+
+
+def _extract_parameter_xml(firmware_json, firmware_path):
+    autopilot = firmware_json.get(MAV_AUTOPILOT_KEY)
+    if autopilot is not None and autopilot != MAV_AUTOPILOT_PX4:
+        raise MetadataExtractError(f"{firmware_path} is not PX4 firmware (mav_autopilot={autopilot})")
+
+    if PARAM_XML_SIZE_KEY not in firmware_json:
+        raise MetadataExtractError(f"{firmware_path} is missing {PARAM_XML_SIZE_KEY}")
+    if PARAM_XML_KEY not in firmware_json:
+        raise MetadataExtractError(f"{firmware_path} is missing {PARAM_XML_KEY}")
+
+    expected_size = firmware_json[PARAM_XML_SIZE_KEY]
+    if not isinstance(expected_size, int) or expected_size <= 0:
+        raise MetadataExtractError(f"{firmware_path} has invalid {PARAM_XML_SIZE_KEY}")
+
+    encoded_xml = firmware_json[PARAM_XML_KEY]
+    if not isinstance(encoded_xml, str) or not encoded_xml:
+        raise MetadataExtractError(f"{firmware_path} has invalid {PARAM_XML_KEY}")
+
+    encoded_xml = "".join(encoded_xml.split())
+    try:
+        compressed_xml = base64.b64decode(encoded_xml, validate=True)
+    except ValueError as error:
+        raise MetadataExtractError(f"{firmware_path} has invalid base64 in {PARAM_XML_KEY}: {error}") from error
+
+    try:
+        parameter_xml = zlib.decompress(compressed_xml)
+    except zlib.error as error:
+        raise MetadataExtractError(f"Unable to decompress {PARAM_XML_KEY}: {error}") from error
+
+    if len(parameter_xml) != expected_size:
+        raise MetadataExtractError(
+            f"Decompressed XML size mismatch: expected {expected_size}, got {len(parameter_xml)}"
+        )
+
+    return parameter_xml
+
+
+def _validate_parameter_xml(parameter_xml, source_name):
+    try:
+        root = ET.fromstring(parameter_xml)
+    except ET.ParseError as error:
+        raise MetadataExtractError(f"Extracted parameter metadata is not valid XML: {error}") from error
+
+    major_element = root.find(".//parameter_version_major")
+    minor_element = root.find(".//parameter_version_minor")
+    if major_element is None or major_element.text is None:
+        raise MetadataExtractError(f"{source_name} metadata is missing parameter_version_major")
+    if minor_element is None or minor_element.text is None:
+        raise MetadataExtractError(f"{source_name} metadata is missing parameter_version_minor")
+
+    try:
+        major_version = int(major_element.text.strip())
+        minor_version = int(minor_element.text.strip())
+    except ValueError as error:
+        raise MetadataExtractError(f"{source_name} metadata has an invalid parameter version") from error
+
+    if major_version != 1:
+        raise MetadataExtractError(f"{source_name} metadata has unsupported major version {major_version}")
+
+    return major_version, minor_version
+
+
+def extract_metadata(firmware_path, output_path, force):
+    firmware_json = _read_firmware_json(firmware_path)
+    parameter_xml = _extract_parameter_xml(firmware_json, firmware_path)
+    major_version, minor_version = _validate_parameter_xml(parameter_xml, firmware_path)
+
+    if output_path.exists() and not force:
+        raise MetadataExtractError(f"{output_path} already exists; pass --force to overwrite")
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(parameter_xml)
+    except OSError as error:
+        raise MetadataExtractError(f"Unable to write {output_path}: {error}") from error
+
+    return major_version, minor_version, len(parameter_xml)
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Extract PX4 parameter metadata XML from a .px4/.apj firmware file."
+    )
+    parser.add_argument("firmware", type=Path, help="PX4 firmware file containing parameter_xml")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Output XML path. Defaults to <firmware>.parameter.xml next to the firmware file.",
+    )
+    parser.add_argument("-f", "--force", action="store_true", help="Overwrite the output file if it already exists.")
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = _parse_args(argv)
+    firmware_path = args.firmware
+    output_path = args.output if args.output else _default_output_path(firmware_path)
+
+    try:
+        major_version, minor_version, xml_size = extract_metadata(firmware_path, output_path, args.force)
+    except MetadataExtractError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {output_path}")
+    print(f"PX4 parameter metadata version {major_version}.{minor_version}, {xml_size} bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

Adds a **"Pull New Metadata..."** action to the Parameter Editor Tools menu. Select a PX4 firmware (`.px4` / `.apj`) or parameter metadata XML (`.xml`) file; the metadata is extracted, decompressed, cached, and reapplied to the currently loaded parameters, refreshing the editor in place.

This is the "upload a file to get new metadata" capability, integrated onto the `AAGS-4.3.0-2.0.4` line.

## Changes

- **CompInfoParam** — `cachePX4MetaDataFromFile()` / `usePX4MetaDataFile()`: read, decompress (`qUncompress`), and cache PX4 parameter metadata from a firmware or XML file.
- **ParameterEditorController** — `pullNewMetadataFromFile()` (PX4-only guard, applies cached metadata) and `_rebuildLists()` (rebuilds the editor tree after import).
- **ParameterEditor.qml** — new "Pull New Metadata..." menu item and file-dialog filters, kept **alongside** the existing "Pull Metadata from Vehicle" action.
- **tools/** — `extract_px4_parameter_metadata.py` (offline extractor) and `bundle_zlib_macos.sh` (macOS post-link zlib bundling).
- **Tests** — `ParameterMetadataImportTest` (XML cache, firmware cache, imported-XML lookup) registered in the unit-test list.

## Integration note

The source change was authored against an older QGC baseline that bundled this feature together with reversions of work already on `AAGS-4.3.0-2.0.4` (regex parameter search, read-only-param diff handling, the incorrect-cast fix, and the modern dialog API). This PR applies **only the additive metadata-import parts** and preserves the existing branch behavior. Line endings kept as LF (the source stored these files as CRLF).

## Verification

- Feature was tested working on the originating (cam) branch.
- All API dependencies confirmed present on this base (`compInfoManager->compInfoParam()`, `reapplyMetadataToAllFacts()`, `FirmwarePlugin::_loadParameterMetaData/_getMetaDataForFact`).
- Recommend a CI/local Qt build + running `ParameterMetadataImportTest` before merge — a full build was not run as part of this change.
